### PR TITLE
Go to original window after updating breakpoint

### DIFF
--- a/autoload/conque_gdb.vim
+++ b/autoload/conque_gdb.vim
@@ -283,6 +283,7 @@ function! conque_gdb#breakpoint(fname, lineno)
     let l:fname = s:escape_to_shell_file(l:fname_py)
 
     if l:perm != ''
+        let l:original_win = winnr()
         call s:open_file(l:fname, l:lineno, l:perm)
 
         sil exe 'noautocmd ' . s:src_bufwin . 'wincmd w'
@@ -292,7 +293,7 @@ function! conque_gdb#breakpoint(fname, lineno)
         call conque_gdb#update_pointer(l:fname_py, l:lineno) 
         call s:buf_update()
 
-        sil exe 'noautocmd wincmd p'
+        sil exe 'noautocmd ' . l:original_win . 'wincmd w'
     else
         " Gdb should detect that the file can't be opened. This should not happen.
         echohl WarningMsg | echomsg 'ConqueGdb: Unable to open file ' . a:fname | echohl None


### PR DESCRIPTION
Fix an issue that causes the cursor to sometimes jump to the taglist
window while debugging with Conque GDB while taglist window is open.

Perform the following steps to reproduce the issue.

Install exuberant-ctags, taglist and Conque GDB.

```
aptitude install exuberant-ctags
wget http://www.vim.org/scripts/download_script.php?src_id=19574 -O taglist.zip
unzip taglist.zip -d ~/.vim
wget "http://www.vim.org/scripts/download_script.php?src_id=22163" -O conque_gdb.vmb
vim +"silent so % | q" conque_gdb.vmb
```

Create a file called foo.c with the following C code.

```
#include <stdio.h>

void foo()
{
    printf("1\n");
    printf("2\n");
    printf("3\n");
}

int main()
{
    printf("1\n");
    printf("2\n");
    foo();
    printf("3\n");
    return 0;
}
```

Compile the C code. Then launch Vim with the source code.

```
$ gcc -g foo.c
$ vim foo.c
```

In Vim, execute the following commands.

```
:TlistOpen
Ctrl-w w
:ConqueGdb a.out
```

Then in GDB, execute the following commands.

```
break main
next
next
step
next
```

At some point while executing these commands, the cursor moves
to the taglist window. One now has to enter
`<Esc> Ctrl-w w Ctrl-w w` to return back to the GDB window. This
is a major inconvenience while debugging.

This occurs because in conque_gdb#breakpoint function, after
moving to another window, it uses the `noautocmd wincmd p`
command to return to the previous window. Normally, this works
fine because this is the sequence in which Conque GDB moves from
one window to another:

```
    (Previous window)
    +--------------+
    V              |
GDB window -> Code window
```

But when taglist is also being used, previous window is no
longer the GDB window. When we `step` into a new function using
GDB, and execute `next`, taglist moves to the taglist window to
update what it shows and then returns to the code window.
Therefore, now when GDB tries to move to the previous window,
the previous window is the taglist window as shown below.

```
                                      (Previous window)
                                      +----------------+
                                      V                |
GDB window -> Code window -> taglist window -> Code window
```

This is the cause of the issue.
