### PR TITLE
Import collections from collections.abc

### DIFF
--- a/autoload/conque_gdb/conque_gdb.py
+++ b/autoload/conque_gdb/conque_gdb.py
@@ -1,4 +1,11 @@
-import re, collections
+import re
+
+try:
+    # Accessing collections abstract classes from collections
+    # has been deprecated since Python 3.3
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 # Marks that a breakpoint has been hit
 GDB_BREAK_MARK = '\x1a\x1a'
@@ -36,7 +43,7 @@ class RegisteredBreakpoint:
     def __str__(self):
         return self.filename + ':' + self.lineno + ',' + self.enabled
 
-class RegisteredBpDict(collections.MutableMapping):
+class RegisteredBpDict(collections_abc.MutableMapping):
     def __init__(self):
         self.r_breaks = dict()
         self.lookups = dict()
@@ -102,7 +109,7 @@ class ConqueGdb(Conque):
     # Breakpoints which have been registered to exist
     registered_breakpoints = RegisteredBpDict()
 
-    # Mapping from linenumber + filename to a tuple containing the id of the sign 
+    # Mapping from linenumber + filename to a tuple containing the id of the sign
     # placed there and whether the breakpoint is enabled ('y') or disabled ('n')
     lookup_sign_ids = dict()
 


### PR DESCRIPTION
Hello,
This gets rid of an error on startup when using ViM 8.1.1050 on Mac OS 10.14.3 with python 2.7.15.

`Error detected while processing function conque_gdb#load_python:
line    6:
/must>not&exist/foo:39: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
Press ENTER or type command to continue
`

Not sure why this error was occurring exactly if I'm on Python 2.7.15 and it's deprecated in Python 3.3 so it's possible that ViM is using a later version of Python. However the fallback behavior in the catch ImportError block performs the original now deprecated import for users on older versions.

This is based on a NumPy PR found here - https://github.com/numpy/numpy/pull/10743/files