### PR TITLE
replace obsolete python syntax

### DIFF
--- a/autoload/conque_gdb/conque_gdb.py
+++ b/autoload/conque_gdb/conque_gdb.py
@@ -1,4 +1,5 @@
-import re, collections
+import re
+from collections.abc import MutableMapping
 
 # Marks that a breakpoint has been hit
 GDB_BREAK_MARK = '\x1a\x1a'
@@ -36,7 +37,7 @@ class RegisteredBreakpoint:
     def __str__(self):
         return self.filename + ':' + self.lineno + ',' + self.enabled
 
-class RegisteredBpDict(collections.MutableMapping):
+class RegisteredBpDict(MutableMapping):
     def __init__(self):
         self.r_breaks = dict()
         self.lookups = dict()


### PR DESCRIPTION
the patch fixes following error: DeprecationWarning: Using or importing
the ABCs from 'collections' instead of from 'collections.abc' is
deprecated, and in 3.8 it will stop working.