### PR TITLE
Fix error on python 3

### DIFF
--- a/autoload/conque_gdb/conque_gdb.py
+++ b/autoload/conque_gdb/conque_gdb.py
@@ -1,4 +1,10 @@
-import re, collections
+import re
+try:
+    # Python 3
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7
+    from collections import MutableMapping
 
 # Marks that a breakpoint has been hit
 GDB_BREAK_MARK = '\x1a\x1a'
@@ -36,7 +42,7 @@ class RegisteredBreakpoint:
     def __str__(self):
         return self.filename + ':' + self.lineno + ',' + self.enabled
 
-class RegisteredBpDict(collections.MutableMapping):
+class RegisteredBpDict(MutableMapping):
     def __init__(self):
         self.r_breaks = dict()
         self.lookups = dict()


### PR DESCRIPTION
Prevent error:

> Error detected while processing function conque_gdb#load_python:
line    6:
/must>not&exist/foo:39: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
