### PR TITLE
Suppress Deprecation Warning from conque_gdb.py

### DIFF
--- a/autoload/conque_gdb/conque_gdb.py
+++ b/autoload/conque_gdb/conque_gdb.py
@@ -1,4 +1,5 @@
-import re, collections
+import re
+import collections.abc as collections
 
 # Marks that a breakpoint has been hit
 GDB_BREAK_MARK = '\x1a\x1a'


### PR DESCRIPTION
Prior to this change I encountered the follow message on startup:

    Error detected while processing function conque_gdb#load_python:
    line    6:
    ~/.vim/bundle/Conque-GDB/autoload/conque_gdb/conque_gdb.py:39: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
      class RegisteredBpDict(collections.MutableMapping):

This change simply aliases the collections module to collections.abc.