### PR TITLE
Fix python3 collections import

### DIFF
--- a/autoload/conque_gdb/conque_gdb.py
+++ b/autoload/conque_gdb/conque_gdb.py
@@ -1,4 +1,9 @@
 import re, collections
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 # Marks that a breakpoint has been hit
 GDB_BREAK_MARK = '\x1a\x1a'
@@ -36,7 +41,7 @@ class RegisteredBreakpoint:
     def __str__(self):
         return self.filename + ':' + self.lineno + ',' + self.enabled
 
-class RegisteredBpDict(collections.MutableMapping):
+class RegisteredBpDict(MutableMapping):
     def __init__(self):
         self.r_breaks = dict()
         self.lookups = dict()


### PR DESCRIPTION
Fix error on new python versions https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/.vim/bundle/Conque-GDB/autoload/conque_gdb/conque_gdb.py", line 39, in <module>
    class RegisteredBpDict(collections.abc.MutableMapping):
AttributeError: module 'collections' has no attribute 'abc'
Press ENTER or type command to continue
